### PR TITLE
Split into modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,22 @@ This file is different from the `config/config.json` file that controls paramete
 
 This means you no longer need to manually run `/am reload` after changing the rules, although the command is still available for convenience.
 
+## Code Structure
+
+For those interested in contributing or understanding the plugin's internals, the codebase is organized into several modules within the `src/` directory. This modular approach separates concerns, making the code easier to maintain and extend.
+
+*   `index.js`: The main entry point of the plugin. It is responsible for initializing all other modules, wiring them together, and registering commands and file watchers with TheLounge API. It acts as the central orchestrator.
+
+*   `src/logger.js`: A wrapper around TheLounge's native logger. It provides standard `info` and `error` methods, along with a `debug` method that only prints messages when debug mode is enabled in the plugin's configuration.
+
+*   `src/plugin-config.js`: Manages the plugin's internal configuration file (`config.json`). This file stores settings like the debug mode status. This module handles loading, saving, and providing access to these settings.
+
+*   `src/rule-manager.js`: Responsible for everything related to the user-defined rules (`rules.json`). It handles loading, parsing, and providing access to the rules. In the future, it will also contain the logic for adding, removing, and updating rules via commands.
+
+*   `src/message-handler.js`: Contains the core logic of the plugin. It defines the `privmsg` event handler that checks incoming messages against the rules from the `rule-manager` and decides when to trigger a response. It also manages rule cooldowns.
+
+*   `src/commands.js`: Defines the `/am` command and all its subcommands (`start`, `stop`, `reload`, `debug`, etc.). It acts as the user-facing interface, calling functions from other modules to execute the requested actions.
+
 ## Debugging
 
 The plugin includes a debug mode that provides verbose logging, which can be useful for troubleshooting rules or reporting issues. You can control this mode in real-time using commands.

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ The file should contain an array of rule objects. Each rule object defines a tri
 ### Rule properties
 
 *   `server` (string): The name of the network/server where this rule applies (e.g., "freenode", "MyCustomServer").
-*   `listen_channel` (string): The channel name (e.g., `#my-project`) or `PrivateMessages` for private messages (**this function has not been tested sufficiently**, if you try it, post issues) where the plugin should listen for triggers.
+*   `listen_channel` (string): The channel name (e.g., `#my-project`) where the plugin should listen for triggers.
 *   `trigger_text` (string): The text that must be included in a message to trigger the response.
 *   `response_message` (string): The message that the plugin will send in response.
-*   `response_channel` (string, optional): The channel or user to which the response should be sent. If not provided, the response is sent to the `listen_channel`. You can use `NickOfSender` to respond directly to the user who triggered the rule (**this function has not been tested sufficiently**, if you try it, post issues).
+*   `response_channel` (string, optional): The channel or user to which the response should be sent. If not provided, the response is sent to the `listen_channel`.
 *   `cooldown_seconds` (number, optional): The number of seconds the rule must wait before it can be triggered again. This is useful to prevent flooding. If not specified, it defaults to **5 seconds**.
 
 ### File location

--- a/index.js
+++ b/index.js
@@ -14,8 +14,14 @@ module.exports = {
     PluginLogger.init(api.Logger, pluginConfigManager);
     PluginLogger.info('[AM] Plugin loaded.');
 
-    // 2. Determine config paths and initialize managers.
+    // 2. Determine config path and ensure it exists.
     const configDir = path.join(api.Config.getPersistentStorageDir(), 'config');
+    if (!fs.existsSync(configDir)) {
+      PluginLogger.info(`[AM] Creating configuration directory: ${configDir}`);
+      fs.mkdirSync(configDir, { recursive: true });
+    }
+
+    // 3. Initialize managers.
     pluginConfigManager.init(configDir);
     ruleManager.init(configDir);
 

--- a/index.js
+++ b/index.js
@@ -2,397 +2,38 @@
 
 const fs = require('fs');
 const path = require('path');
-
-// Global state for the plugin
-let Logger;
-let rules = [];
- // Path to the configuration file, determined at runtime
-let configFilePath = '';
-// Path to the plugin's own configuration file
-let pluginConfigPath = ''; 
-// Holds the loaded configuration, with a default
-let pluginConfig = { debug: false }; 
-// Key: rule object, Value: last execution timestamp
-const ruleCooldowns = new Map(); 
-// Key: network.uuid, Value: { handler: function, client: object }
-const activeListeners = new Map();
-
-// Wrapper for TheLounge's logger to control debug message visibility
-const PluginLogger = {
-  // Errors are always critical and should be shown.
-  error: (...args) => {
-    if (Logger) Logger.error(...args);
-  },
-  // Info messages are for general plugin status and should always be shown.
-  info: (...args) => {
-    if (Logger) Logger.info(...args);
-  },
-  // Debug messages are verbose and should only be shown when debug mode is enabled.
-  debug: (...args) => {
-    if (pluginConfig.debug && Logger) {
-      Logger.info(...args); // Debug messages are logged at the info level
-    }
-  },
-};
-
-/**
-* A safe version of JSON.stringify that handles circular references,
-* preventing crashes when logging complex objects.
-*/
-function safeJsonStringify(obj) {
-  const cache = new Set();
-  return JSON.stringify(obj, (key, value) => {
-    if (typeof value === 'object' && value !== null) {
-      if (cache.has(value)) {
-        // Circular reference found, discard key
-        return '[Circular]';
-      }
-      // Store value in our collection
-      cache.add(value);
-    }
-    return value;
-  }, 2);
-}
-
-
-/**
-* Loads rules from rules.json into the global `rules` variable.
-* Can optionally send feedback to a user.
-*/
-function loadRules(tellUser) {
-  PluginLogger.debug(`[AM] Attempting to load rules from: ${configFilePath}`);
-  try {
-    const rulesFile = fs.readFileSync(configFilePath, 'utf8');
-    rules = JSON.parse(rulesFile);
-    const message = `Rules successfully reloaded. Found ${rules.length} rules.`;
-    PluginLogger.info(`[AM] ${message}`);
-    // Reset all cooldowns whenever rules are reloaded
-    ruleCooldowns.clear();
-    PluginLogger.debug('[AM] All rule cooldowns have been reset.');
-    if (tellUser) {
-      tellUser(message);
-    }
-  } catch (error) {
-    let errMessage = `ERROR: Could not read rules from ${configFilePath}.`;
-    if (error.code === 'ENOENT') {
-      errMessage = `ERROR: Configuration file not found at ${configFilePath}.`;
-    } else if (error instanceof SyntaxError) {
-      errMessage = `ERROR: Failed to parse ${configFilePath}. Please check for JSON syntax errors.`;
-    }
-    PluginLogger.error(`[AM] ${errMessage}`, error.message);
-    if (tellUser) {
-      tellUser(errMessage);
-    }
-  }
-}
-
-/**
-* Loads the plugin's configuration from config.json into the global `pluginConfig` variable.
-*/
-function loadPluginConfig() {
-  PluginLogger.debug(`[AM] Attempting to load plugin config from: ${pluginConfigPath}`);
-  try {
-    const configFile = fs.readFileSync(pluginConfigPath, 'utf8');
-    pluginConfig = JSON.parse(configFile);
-    PluginLogger.info(`[AM] Plugin config successfully loaded. Debug mode is ${pluginConfig.debug ? 'ENABLED' : 'DISABLED'}.`);
-  } catch (error) {
-    let errMessage = `[AM] ERROR: Could not read plugin config from ${pluginConfigPath}. Using default values.`;
-    if (error.code === 'ENOENT') {
-      errMessage = `[AM] ERROR: Plugin config file not found at ${pluginConfigPath}. Using default values.`;
-    } else if (error instanceof SyntaxError) {
-      errMessage = `[AM] ERROR: Failed to parse ${pluginConfigPath}. Please check for JSON syntax errors. Using default values.`;
-    }
-    PluginLogger.error(errMessage, error.message);
-  }
-}
-
-/**
-* Saves the current in-memory plugin configuration (`pluginConfig`) to the `config.json` file.
-* This function is critical for persisting changes made at runtime, like enabling/disabling debug mode.
-*/
-function savePluginConfig() {
-  PluginLogger.debug(`[AM] Attempting to save plugin config to: ${pluginConfigPath}`);
-  try {
-    fs.writeFileSync(pluginConfigPath, JSON.stringify(pluginConfig, null, 2) + '\n');
-    PluginLogger.debug(`[AM] Plugin config successfully saved to ${pluginConfigPath}.`);
-  } catch (error) {
-    PluginLogger.error(`[AM] CRITICAL ERROR: Failed to save plugin config to ${pluginConfigPath}. Changes may not be persisted.`, error.message);
-  }
-}
-
-/**
-* Ensures the configuration directory and file exist.
-* If they don't, it creates them with default values.
-*/
-function ensureConfigFileExists(configDir) {
-  if (!fs.existsSync(configDir)) {
-    PluginLogger.info(`[AM] Creating configuration directory: ${configDir}`);
-    fs.mkdirSync(configDir, { recursive: true });
-  }
-  
-  if (!fs.existsSync(configFilePath)) {
-    PluginLogger.info(`[AM] Creating default rules file: ${configFilePath}`);
-    const defaultConfig = [
-      {
-        "server": "freenode",
-        "listen_channel": "#my-channel",
-        "trigger_text": "ping",
-        "response_message": "pong",
-        "response_channel": "",
-        "cooldown_seconds": 5
-      }
-    ];
-    fs.writeFileSync(configFilePath, JSON.stringify(defaultConfig, null, 2) + '\n');
-  }
-}
-
-/**
-* Ensures the plugin's own configuration file (`config.json`) exists.
-* If it doesn't, it creates one with default values.
-*/
-function ensurePluginConfigExists() {
-  if (!fs.existsSync(pluginConfigPath)) {
-    PluginLogger.info(`[AM] Creating default plugin config file: ${pluginConfigPath}`);
-    const defaultConfig = {
-      "debug": false
-    };
-    fs.writeFileSync(pluginConfigPath, JSON.stringify(defaultConfig, null, 2) + '\n');
-  }
-}
-
-/**
-* Creates the event handler for 'privmsg' events for a given network.
-* This is where rules are checked and responses are sent.
-*/
-function createPrivmsgHandler(client, network) {
-  return (data) => {
-    // Aggressive logging for every message to help debug rules
-    PluginLogger.debug(`[AM] Received privmsg on network '${network.name}'. Data: ${safeJsonStringify(data)}`);
-    
-    // Iterate over rules
-    for (const rule of rules) {
-      // 1. Check if the rule is for the correct server
-      const serverMatch = rule.server === network.name;
-      
-      // 2. Check if the message is in the correct channel (or is a PM)
-      let channelMatch = false;
-      if (rule.listen_channel.toLowerCase() === 'privatemessages') {
-        // If rule is for PMs, check if the message target is the user's own nick
-        channelMatch = data.target.toLowerCase() === network.irc.user.nick.toLowerCase();
-      } else {
-        // Otherwise, check for a standard channel name match
-        channelMatch = rule.listen_channel.toLowerCase() === data.target.toLowerCase();
-      }
-      
-      // 3. Check if the trigger text is in the message
-      const textMatch = data.message.includes(rule.trigger_text);
-      
-      if (serverMatch && channelMatch && textMatch) {
-        PluginLogger.debug(`[AM] Rule triggered by '${data.nick}' in '${data.target}'. Matched rule: ${safeJsonStringify(rule)}`);
-        
-        // 4. Cooldown check
-        const now = Date.now();
-        const cooldownSeconds = rule.cooldown_seconds === undefined ? 5 : rule.cooldown_seconds;
-        const cooldownMs = cooldownSeconds * 1000;
-        const lastExecuted = ruleCooldowns.get(rule);
-        
-        if (lastExecuted && (now - lastExecuted < cooldownMs)) {
-          PluginLogger.debug(`[AM] Rule for '${rule.trigger_text}' is on cooldown. Skipping.`);
-          continue; // Skip this rule and check the next one
-        }
-        
-        // Determine the target for the response
-        let responseTarget = rule.response_channel || data.target;
-        if (responseTarget.toLowerCase() === 'nickofsender') {
-          responseTarget = data.nick;
-        }
-        
-        // Find the channel object to get its ID for the `runAsUser` command.
-        // Case-insensitive comparison for channel names.
-        const targetChan = network.channels.find(c => c.name.toLowerCase() === responseTarget.toLowerCase());
-        
-        if (!targetChan) {
-          PluginLogger.error(`[AM] Could not find channel '${responseTarget}' to send response. Aborting this trigger.`);
-          continue; // Use continue instead of break to not block other rules
-        }
-        
-        // Set the cooldown timestamp *before* sending the message
-        ruleCooldowns.set(rule, now);
-        
-        // This is equivalent to a /say command, since there is no IRC command specified
-        // It could be changed later to account for more possible commands,
-        // and that in turn would need for me to change this variable name
-        // to something that actually reflects that this is a command and not a message.
-        // For now, it can stay as is. 
-        const responseMessage = `${rule.response_message}`;
-        
-        PluginLogger.debug(`[AM] Sending response to '${responseTarget}' (ID: ${targetChan.id}): ${rule.response_message}`);
-        client.runAsUser(responseMessage, targetChan.id);
-        break; // Stop processing more rules for this message
-      }
-    }
-  };
-}
-
-/**
-* Sends a detailed, multi-line help message to the user, explaining each command.
-* @param {function(string)} tellUser - The function to use for sending messages to the user.
-*/
-function sendHelpMessage(tellUser) {
-  tellUser("--- TheLounge Answering Machine Help ---");
-  tellUser("Usage: /am <command> [args...]");
-  tellUser(" "); // Spacer for readability
-  tellUser("General commands:");
-  tellUser("  start          - Activates the listener for the current network.");
-  tellUser("  stop           - Deactivates the listener for the current network.");
-  tellUser("  status         - Shows if the listener is active or inactive for this network.");
-  tellUser("  reload         - Manually reloads rules from the rules.json file.");
-  tellUser(" ");
-  tellUser("Debugging commands:");
-  tellUser("  debug status   - Shows if debug mode is currently ENABLED or DISABLED.");
-  tellUser("  debug enable   - Enables verbose logging.");
-  tellUser("  debug disable  - Disables verbose logging.");
-}
-
-const answeringMachineCommand = {
-  input(client, target, args) {
-    const [subcommand] = args;
-    const network = target.network;
-    
-    // A helper function to send feedback to the user in the current window.
-    // It uses the 'client' and 'target' objects passed into this 'input' function.
-    const tellUser = (message) => {
-      client.sendMessage(`[AM] ${message}`, target.chan);
-    };
-    
-    switch ((subcommand || '').toLowerCase()) {
-      case 'start': {
-        if (activeListeners.has(network.uuid)) {
-          tellUser(`Listener is already active for this network (${network.name}).`);
-          return;
-        }
-        
-        // Log the full network object to help admins find the correct server name for rules.json
-        PluginLogger.debug(`[AM] Attaching listener for network: ${network.name} (UUID: ${network.uuid}). Full network object: ${safeJsonStringify(network)}`);
-        const handler = createPrivmsgHandler(client, network);
-        network.irc.on('privmsg', handler);
-        activeListeners.set(network.uuid, { handler, client });
-        
-        tellUser(`Listener started for network: ${network.name}.`);
-        PluginLogger.info(`[AM] Listener started for ${client.client.name} on ${network.name}.`);
-        return;
-      }
-      
-      case 'stop': {
-        if (!activeListeners.has(network.uuid)) {
-          tellUser(`Listener is not active for this network (${network.name}).`);
-          return;
-        }
-        
-        const { handler } = activeListeners.get(network.uuid);
-        network.irc.removeListener('privmsg', handler);
-        activeListeners.delete(network.uuid);
-        
-        tellUser(`Listener stopped for network: ${network.name}.`);
-        PluginLogger.info(`[AM] Listener stopped for ${client.client.name} on ${network.name}.`);
-        return;
-      }
-      
-      case 'status': {
-        if (activeListeners.has(network.uuid)) {
-          tellUser(`Listener is ACTIVE for network: ${network.name}.`);
-        } else {
-          tellUser(`Listener is INACTIVE for network: ${network.name}.`);
-        }
-        return;
-      }
-      
-      case 'reload': {
-        loadRules(tellUser);
-        return;
-      }
-      
-      case 'debug': {
-        const [debugSubCommand] = args.slice(1);
-        switch ((debugSubCommand || '').toLowerCase()) {
-          case 'enable': {
-            if (pluginConfig.debug) {
-              tellUser('Debug mode is already ENABLED.');
-            } else {
-              pluginConfig.debug = true;
-              savePluginConfig();
-              tellUser('Debug mode has been ENABLED. The change has been saved.');
-            }
-            break;
-          }
-          case 'disable': {
-            if (!pluginConfig.debug) {
-              tellUser('Debug mode is already DISABLED.');
-            } else {
-              pluginConfig.debug = false;
-              savePluginConfig();
-              tellUser('Debug mode has been DISABLED. The change has been saved.');
-            }
-            break;
-          }
-          case 'status': {
-            tellUser(`Debug mode is currently ${pluginConfig.debug ? 'ENABLED' : 'DISABLED'}.`);
-            break;
-          }
-          default: {
-            sendHelpMessage(tellUser);
-            break;
-          }
-        }
-        return;
-      }
-      
-      default: {
-        sendHelpMessage(tellUser);
-        return;
-      }
-    }
-  },
-  allowDisconnected: false,
-};
+const { PluginLogger } = require('./src/logger');
+const pluginConfigManager = require('./src/plugin-config');
+const ruleManager = require('./src/rule-manager');
+const { answeringMachineCommand } = require('./src/commands');
 
 module.exports = {
   onServerStart(api) {
-    // Make the logger available globally
-    Logger = api.Logger;
-    
+    // 1. Initialize logger, injecting the config manager as its provider.
+    // This must be done first so other modules can log during their initialization.
+    PluginLogger.init(api.Logger, pluginConfigManager);
     PluginLogger.info('[AM] Plugin loaded.');
-    
-    // Determine the configuration paths
+
+    // 2. Determine config paths and initialize managers.
     const configDir = path.join(api.Config.getPersistentStorageDir(), 'config');
-    configFilePath = path.join(configDir, 'rules.json');
-    pluginConfigPath = path.join(configDir, 'config.json'); // Path for plugin's own config
-    PluginLogger.info(`[AM] Using rules file: ${configFilePath}`);
-    PluginLogger.info(`[AM] Using plugin config file: ${pluginConfigPath}`);
-    
-    // Ensure the configuration directory and files exist
-    ensureConfigFileExists(configDir);
-    ensurePluginConfigExists();
-    
-    // Initial load of rules and config on startup
-    loadPluginConfig();
-    loadRules();
-    
-    // Watch for changes in the configuration files
-    PluginLogger.info(`[AM] Watching for file changes on: ${configFilePath}`);
-    fs.watchFile(configFilePath, { interval: 5007 }, (curr, prev) => {
+    pluginConfigManager.init(configDir);
+    ruleManager.init(configDir);
+
+    // 3. Watch for changes in configuration files.
+    const rulesPath = ruleManager.getRulesPath();
+    PluginLogger.info(`[AM] Watching for file changes on: ${rulesPath}`);
+    fs.watchFile(rulesPath, { interval: 5007 }, (curr, prev) => {
       if (curr.mtimeMs === 0) {
-        // File was likely deleted or is temporarily unavailable
         PluginLogger.info('[AM] Watched rules file is not accessible or has been deleted.');
         return;
       }
       if (curr.mtime !== prev.mtime) {
-        PluginLogger.info(`[AM] Change detected in ${configFilePath}. Reloading rules...`);
-        // No user feedback on automatic reload
-        loadRules();
+        PluginLogger.info(`[AM] Change detected in ${rulesPath}. Reloading rules...`);
+        ruleManager.loadRules();
       }
     });
     
+    const pluginConfigPath = pluginConfigManager.getPluginConfigPath();
     PluginLogger.info(`[AM] Watching for file changes on: ${pluginConfigPath}`);
     fs.watchFile(pluginConfigPath, { interval: 5007 }, (curr, prev) => {
       if (curr.mtimeMs === 0) {
@@ -401,11 +42,11 @@ module.exports = {
       }
       if (curr.mtime !== prev.mtime) {
         PluginLogger.info(`[AM] Change detected in ${pluginConfigPath}. Reloading plugin configuration...`);
-        loadPluginConfig();
+        pluginConfigManager.loadPluginConfig();
       }
     });
-    
-    // Register the command with TheLounge
+
+    // 4. Register the command with TheLounge.
     api.Commands.add('am', answeringMachineCommand);
     PluginLogger.info('[AM] Command /am registered.');
   },

--- a/src/commands.js
+++ b/src/commands.js
@@ -29,7 +29,7 @@ function sendHelpMessage(tellUser) {
 }
 
 const answeringMachineCommand = {
-  input(client, target, args) {
+  input(client, target, _command, args) {
     const [subcommand] = args;
     const network = target.network;
     

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const { PluginLogger } = require('./logger');
+const pluginConfigManager = require('./plugin-config');
+const ruleManager = require('./rule-manager');
+const { createPrivmsgHandler, safeJsonStringify } = require('./message-handler');
+
+// Key: network.uuid, Value: { handler: function, client: object }
+const activeListeners = new Map();
+
+/**
+* Sends a detailed, multi-line help message to the user.
+* @param {function(string)} tellUser - The function to use for sending messages to the user.
+*/
+function sendHelpMessage(tellUser) {
+  tellUser("--- TheLounge Answering Machine Help ---");
+  tellUser("Usage: /am <command> [args...]");
+  tellUser(" "); // Spacer for readability
+  tellUser("General commands:");
+  tellUser("  start          - Activates the listener for the current network.");
+  tellUser("  stop           - Deactivates the listener for the current network.");
+  tellUser("  status         - Shows if the listener is active or inactive for this network.");
+  tellUser("  reload         - Manually reloads rules from the rules.json file.");
+  tellUser(" ");
+  tellUser("Debugging commands:");
+  tellUser("  debug status   - Shows if debug mode is currently ENABLED or DISABLED.");
+  tellUser("  debug enable   - Enables verbose logging.");
+  tellUser("  debug disable  - Disables verbose logging.");
+}
+
+const answeringMachineCommand = {
+  input(client, target, args) {
+    const [subcommand] = args;
+    const network = target.network;
+    
+    const tellUser = (message) => {
+      client.sendMessage(`[AM] ${message}`, target.chan);
+    };
+    
+    switch ((subcommand || '').toLowerCase()) {
+      case 'start': {
+        if (activeListeners.has(network.uuid)) {
+          tellUser(`Listener is already active for this network (${network.name}).`);
+          return;
+        }
+        
+        PluginLogger.debug(`[AM] Attaching listener for network: ${network.name} (UUID: ${network.uuid}). Full network object: ${safeJsonStringify(network)}`);
+        const handler = createPrivmsgHandler(client, network);
+        network.irc.on('privmsg', handler);
+        activeListeners.set(network.uuid, { handler, client });
+        
+        tellUser(`Listener started for network: ${network.name}.`);
+        PluginLogger.info(`[AM] Listener started for ${client.client.name} on ${network.name}.`);
+        return;
+      }
+      
+      case 'stop': {
+        if (!activeListeners.has(network.uuid)) {
+          tellUser(`Listener is not active for this network (${network.name}).`);
+          return;
+        }
+        
+        const { handler } = activeListeners.get(network.uuid);
+        network.irc.removeListener('privmsg', handler);
+        activeListeners.delete(network.uuid);
+        
+        tellUser(`Listener stopped for network: ${network.name}.`);
+        PluginLogger.info(`[AM] Listener stopped for ${client.client.name} on ${network.name}.`);
+        return;
+      }
+      
+      case 'status': {
+        if (activeListeners.has(network.uuid)) {
+          tellUser(`Listener is ACTIVE for network: ${network.name}.`);
+        } else {
+          tellUser(`Listener is INACTIVE for network: ${network.name}.`);
+        }
+        return;
+      }
+      
+      case 'reload': {
+        ruleManager.loadRules(tellUser);
+        return;
+      }
+      
+      case 'debug': {
+        const [debugSubCommand] = args.slice(1);
+        const config = pluginConfigManager.getPluginConfig();
+        switch ((debugSubCommand || '').toLowerCase()) {
+          case 'enable': {
+            if (config.debug) {
+              tellUser('Debug mode is already ENABLED.');
+            } else {
+              config.debug = true;
+              pluginConfigManager.savePluginConfig();
+              tellUser('Debug mode has been ENABLED. The change has been saved.');
+            }
+            break;
+          }
+          case 'disable': {
+            if (!config.debug) {
+              tellUser('Debug mode is already DISABLED.');
+            } else {
+              config.debug = false;
+              pluginConfigManager.savePluginConfig();
+              tellUser('Debug mode has been DISABLED. The change has been saved.');
+            }
+            break;
+          }
+          case 'status': {
+            tellUser(`Debug mode is currently ${config.debug ? 'ENABLED' : 'DISABLED'}.`);
+            break;
+          }
+          default: {
+            sendHelpMessage(tellUser);
+            break;
+          }
+        }
+        return;
+      }
+      
+      default: {
+        sendHelpMessage(tellUser);
+        return;
+      }
+    }
+  },
+  allowDisconnected: false,
+};
+
+module.exports = {
+  answeringMachineCommand,
+};

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,43 @@
+
+'use strict';
+
+/**
+ * This module provides a logging wrapper around TheLounge's logger.
+ * It is initialized with a config provider to allow for conditional debug logging.
+ */
+
+let Logger; // TheLounge's logger instance, set on init
+let configProvider; // A module that provides getPluginConfig(), e.g., plugin-config.js
+
+const PluginLogger = {
+  /**
+   * Initializes the logger.
+   * @param {object} loggerInstance - TheLounge's logger instance.
+   * @param {object} cfgProvider - A module with a getPluginConfig() method.
+   */
+  init: (loggerInstance, cfgProvider) => {
+    Logger = loggerInstance;
+    configProvider = cfgProvider;
+  },
+
+  // Errors are always critical and should be shown.
+  error: (...args) => {
+    if (Logger) Logger.error(...args);
+  },
+
+  // Info messages are for general plugin status and should always be shown.
+  info: (...args) => {
+    if (Logger) Logger.info(...args);
+  },
+
+  // Debug messages are verbose and only shown when debug mode is enabled in the config.
+  debug: (...args) => {
+    if (configProvider && configProvider.getPluginConfig().debug && Logger) {
+      Logger.info(...args); // Debug messages are logged at the info level
+    }
+  },
+};
+
+module.exports = {
+  PluginLogger,
+};

--- a/src/message-handler.js
+++ b/src/message-handler.js
@@ -32,14 +32,7 @@ function createPrivmsgHandler(client, network) {
     
     for (const rule of rules) {
       const serverMatch = rule.server === network.name;
-      
-      let channelMatch = false;
-      if (rule.listen_channel.toLowerCase() === 'privatemessages') {
-        channelMatch = data.target.toLowerCase() === network.irc.user.nick.toLowerCase();
-      } else {
-        channelMatch = rule.listen_channel.toLowerCase() === data.target.toLowerCase();
-      }
-      
+      const channelMatch = rule.listen_channel.toLowerCase() === data.target.toLowerCase();
       const textMatch = data.message.includes(rule.trigger_text);
       
       if (serverMatch && channelMatch && textMatch) {
@@ -55,11 +48,7 @@ function createPrivmsgHandler(client, network) {
           continue;
         }
         
-        let responseTarget = rule.response_channel || data.target;
-        if (responseTarget.toLowerCase() === 'nickofsender') {
-          responseTarget = data.nick;
-        }
-        
+        const responseTarget = rule.response_channel || data.target;
         const targetChan = network.channels.find(c => c.name.toLowerCase() === responseTarget.toLowerCase());
         
         if (!targetChan) {
@@ -69,6 +58,13 @@ function createPrivmsgHandler(client, network) {
         
         ruleCooldowns.set(rule, now);
         
+        /**
+         * The naming of this variable assumes the plugin is always sending messages to public channels.
+         * Since /say is the default command, this works. However, if in the future we add 
+         * the possibility of using other commands, like sending a private message, we should
+         * rewrite this block of code to properly react to those.
+         * Reference documentation: https://en.wikipedia.org/wiki/List_of_IRC_commands
+         */
         const responseMessage = `${rule.response_message}`;
         
         PluginLogger.debug(`[AM] Sending response to '${responseTarget}' (ID: ${targetChan.id}): ${rule.response_message}`);

--- a/src/message-handler.js
+++ b/src/message-handler.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const { PluginLogger } = require('./logger');
+const ruleManager = require('./rule-manager');
+
+/**
+* A safe version of JSON.stringify that handles circular references.
+*/
+function safeJsonStringify(obj) {
+  const cache = new Set();
+  return JSON.stringify(obj, (key, value) => {
+    if (typeof value === 'object' && value !== null) {
+      if (cache.has(value)) {
+        return '[Circular]';
+      }
+      cache.add(value);
+    }
+    return value;
+  }, 2);
+}
+
+/**
+* Creates the event handler for 'privmsg' events for a given network.
+*/
+function createPrivmsgHandler(client, network) {
+  return (data) => {
+    // Fetch fresh rules and cooldowns on every message to ensure they are not stale.
+    const rules = ruleManager.getRules();
+    const ruleCooldowns = ruleManager.getRuleCooldowns();
+
+    PluginLogger.debug(`[AM] Received privmsg on network '${network.name}'. Data: ${safeJsonStringify(data)}`);
+    
+    for (const rule of rules) {
+      const serverMatch = rule.server === network.name;
+      
+      let channelMatch = false;
+      if (rule.listen_channel.toLowerCase() === 'privatemessages') {
+        channelMatch = data.target.toLowerCase() === network.irc.user.nick.toLowerCase();
+      } else {
+        channelMatch = rule.listen_channel.toLowerCase() === data.target.toLowerCase();
+      }
+      
+      const textMatch = data.message.includes(rule.trigger_text);
+      
+      if (serverMatch && channelMatch && textMatch) {
+        PluginLogger.debug(`[AM] Rule triggered by '${data.nick}' in '${data.target}'. Matched rule: ${safeJsonStringify(rule)}`);
+        
+        const now = Date.now();
+        const cooldownSeconds = rule.cooldown_seconds === undefined ? 5 : rule.cooldown_seconds;
+        const cooldownMs = cooldownSeconds * 1000;
+        const lastExecuted = ruleCooldowns.get(rule);
+        
+        if (lastExecuted && (now - lastExecuted < cooldownMs)) {
+          PluginLogger.debug(`[AM] Rule for '${rule.trigger_text}' is on cooldown. Skipping.`);
+          continue;
+        }
+        
+        let responseTarget = rule.response_channel || data.target;
+        if (responseTarget.toLowerCase() === 'nickofsender') {
+          responseTarget = data.nick;
+        }
+        
+        const targetChan = network.channels.find(c => c.name.toLowerCase() === responseTarget.toLowerCase());
+        
+        if (!targetChan) {
+          PluginLogger.error(`[AM] Could not find channel '${responseTarget}' to send response. Aborting this trigger.`);
+          continue;
+        }
+        
+        ruleCooldowns.set(rule, now);
+        
+        const responseMessage = `${rule.response_message}`;
+        
+        PluginLogger.debug(`[AM] Sending response to '${responseTarget}' (ID: ${targetChan.id}): ${rule.response_message}`);
+        client.runAsUser(responseMessage, targetChan.id);
+        break;
+      }
+    }
+  };
+}
+
+module.exports = {
+  createPrivmsgHandler,
+  safeJsonStringify,
+};

--- a/src/plugin-config.js
+++ b/src/plugin-config.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { PluginLogger } = require('./logger');
+
+// Default state
+let pluginConfig = { debug: false };
+let pluginConfigPath = '';
+
+/**
+ * Initializes the plugin configuration module.
+ * @param {string} configDir - The base directory for configuration files.
+ */
+function init(configDir) {
+  pluginConfigPath = path.join(configDir, 'config.json');
+  PluginLogger.info(`[AM] Using plugin config file: ${pluginConfigPath}`);
+  ensurePluginConfigExists();
+  loadPluginConfig();
+}
+
+/**
+ * Loads the plugin's configuration from config.json.
+ */
+function loadPluginConfig() {
+  PluginLogger.debug(`[AM] Attempting to load plugin config from: ${pluginConfigPath}`);
+  try {
+    const configFile = fs.readFileSync(pluginConfigPath, 'utf8');
+    pluginConfig = JSON.parse(configFile);
+    PluginLogger.info(`[AM] Plugin config successfully loaded. Debug mode is ${pluginConfig.debug ? 'ENABLED' : 'DISABLED'}.`);
+  } catch (error) {
+    let errMessage = `[AM] ERROR: Could not read plugin config from ${pluginConfigPath}. Using default values.`;
+    if (error.code === 'ENOENT') {
+      errMessage = `[AM] ERROR: Plugin config file not found at ${pluginConfigPath}. Using default values.`;
+    } else if (error instanceof SyntaxError) {
+      errMessage = `[AM] ERROR: Failed to parse ${pluginConfigPath}. Please check for JSON syntax errors. Using default values.`;
+    }
+    PluginLogger.error(errMessage, error.message);
+  }
+}
+
+/**
+ * Saves the current in-memory plugin configuration to config.json.
+ */
+function savePluginConfig() {
+  PluginLogger.debug(`[AM] Attempting to save plugin config to: ${pluginConfigPath}`);
+  try {
+    fs.writeFileSync(pluginConfigPath, JSON.stringify(pluginConfig, null, 2) + '\n');
+    PluginLogger.debug(`[AM] Plugin config successfully saved to ${pluginConfigPath}.`);
+  } catch (error) {
+    PluginLogger.error(`[AM] CRITICAL ERROR: Failed to save plugin config to ${pluginConfigPath}. Changes may not be persisted.`, error.message);
+  }
+}
+
+/**
+ * Ensures the config.json file exists, creating it with defaults if not.
+ */
+function ensurePluginConfigExists() {
+  if (!fs.existsSync(pluginConfigPath)) {
+    PluginLogger.info(`[AM] Creating default plugin config file: ${pluginConfigPath}`);
+    const defaultConfig = { "debug": false };
+    fs.writeFileSync(pluginConfigPath, JSON.stringify(defaultConfig, null, 2) + '\n');
+  }
+}
+
+/**
+ * Returns the current plugin configuration object.
+ * @returns {object}
+ */
+function getPluginConfig() {
+  return pluginConfig;
+}
+
+/**
+ * Returns the path to the plugin's config file.
+ * @returns {string}
+ */
+function getPluginConfigPath() {
+    return pluginConfigPath;
+}
+
+module.exports = {
+  init,
+  loadPluginConfig,
+  savePluginConfig,
+  getPluginConfig,
+  getPluginConfigPath,
+};

--- a/src/rule-manager.js
+++ b/src/rule-manager.js
@@ -9,57 +9,17 @@ let rules = [];
 let configFilePath = '';
 const ruleCooldowns = new Map(); // Key: rule object, Value: last execution timestamp
 
-/**
- * Initializes the rule manager module.
- * @param {string} configDir - The base directory for configuration files.
- */
 function init(configDir) {
   configFilePath = path.join(configDir, 'rules.json');
   PluginLogger.info(`[AM] Using rules file: ${configFilePath}`);
-  ensureConfigFileExists(configDir);
+  ensureConfigFileExists();
   loadRules();
-}
-
-/**
- * Loads rules from rules.json.
- * @param {function(string)} tellUser - Optional callback to send feedback to a user.
- */
-function loadRules(tellUser) {
-  PluginLogger.debug(`[AM] Attempting to load rules from: ${configFilePath}`);
-  try {
-    const rulesFile = fs.readFileSync(configFilePath, 'utf8');
-    rules = JSON.parse(rulesFile);
-    const message = `Rules successfully reloaded. Found ${rules.length} rules.`;
-    PluginLogger.info(`[AM] ${message}`);
-    // Reset all cooldowns whenever rules are reloaded
-    ruleCooldowns.clear();
-    PluginLogger.debug('[AM] All rule cooldowns have been reset.');
-    if (tellUser) {
-      tellUser(message);
-    }
-  } catch (error) {
-    let errMessage = `ERROR: Could not read rules from ${configFilePath}.`;
-    if (error.code === 'ENOENT') {
-      errMessage = `ERROR: Configuration file not found at ${configFilePath}.`;
-    } else if (error instanceof SyntaxError) {
-      errMessage = `ERROR: Failed to parse ${configFilePath}. Please check for JSON syntax errors.`;
-    }
-    PluginLogger.error(`[AM] ${errMessage}`, error.message);
-    if (tellUser) {
-      tellUser(errMessage);
-    }
-  }
 }
 
 /**
  * Ensures the rules.json file exists, creating it with defaults if not.
  */
-function ensureConfigFileExists(configDir) {
-  if (!fs.existsSync(configDir)) {
-    PluginLogger.info(`[AM] Creating configuration directory: ${configDir}`);
-    fs.mkdirSync(configDir, { recursive: true });
-  }
-  
+function ensureConfigFileExists() {
   if (!fs.existsSync(configFilePath)) {
     PluginLogger.info(`[AM] Creating default rules file: ${configFilePath}`);
     const defaultConfig = [

--- a/src/rule-manager.js
+++ b/src/rule-manager.js
@@ -17,6 +17,37 @@ function init(configDir) {
 }
 
 /**
+ * Loads rules from rules.json.
+ * @param {function(string)} tellUser - Optional callback to send feedback to a user.
+ */
+function loadRules(tellUser) {
+  PluginLogger.debug(`[AM] Attempting to load rules from: ${configFilePath}`);
+  try {
+    const rulesFile = fs.readFileSync(configFilePath, 'utf8');
+    rules = JSON.parse(rulesFile);
+    const message = `Rules successfully reloaded. Found ${rules.length} rules.`;
+    PluginLogger.info(`[AM] ${message}`);
+    // Reset all cooldowns whenever rules are reloaded
+    ruleCooldowns.clear();
+    PluginLogger.debug('[AM] All rule cooldowns have been reset.');
+    if (tellUser) {
+      tellUser(message);
+    }
+  } catch (error) {
+    let errMessage = `ERROR: Could not read rules from ${configFilePath}.`;
+    if (error.code === 'ENOENT') {
+      errMessage = `ERROR: Configuration file not found at ${configFilePath}.`;
+    } else if (error instanceof SyntaxError) {
+      errMessage = `ERROR: Failed to parse ${configFilePath}. Please check for JSON syntax errors.`;
+    }
+    PluginLogger.error(`[AM] ${errMessage}`, error.message);
+    if (tellUser) {
+      tellUser(errMessage);
+    }
+  }
+}
+
+/**
  * Ensures the rules.json file exists, creating it with defaults if not.
  */
 function ensureConfigFileExists() {

--- a/src/rule-manager.js
+++ b/src/rule-manager.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { PluginLogger } = require('./logger');
+
+// Default state
+let rules = [];
+let configFilePath = '';
+const ruleCooldowns = new Map(); // Key: rule object, Value: last execution timestamp
+
+/**
+ * Initializes the rule manager module.
+ * @param {string} configDir - The base directory for configuration files.
+ */
+function init(configDir) {
+  configFilePath = path.join(configDir, 'rules.json');
+  PluginLogger.info(`[AM] Using rules file: ${configFilePath}`);
+  ensureConfigFileExists(configDir);
+  loadRules();
+}
+
+/**
+ * Loads rules from rules.json.
+ * @param {function(string)} tellUser - Optional callback to send feedback to a user.
+ */
+function loadRules(tellUser) {
+  PluginLogger.debug(`[AM] Attempting to load rules from: ${configFilePath}`);
+  try {
+    const rulesFile = fs.readFileSync(configFilePath, 'utf8');
+    rules = JSON.parse(rulesFile);
+    const message = `Rules successfully reloaded. Found ${rules.length} rules.`;
+    PluginLogger.info(`[AM] ${message}`);
+    // Reset all cooldowns whenever rules are reloaded
+    ruleCooldowns.clear();
+    PluginLogger.debug('[AM] All rule cooldowns have been reset.');
+    if (tellUser) {
+      tellUser(message);
+    }
+  } catch (error) {
+    let errMessage = `ERROR: Could not read rules from ${configFilePath}.`;
+    if (error.code === 'ENOENT') {
+      errMessage = `ERROR: Configuration file not found at ${configFilePath}.`;
+    } else if (error instanceof SyntaxError) {
+      errMessage = `ERROR: Failed to parse ${configFilePath}. Please check for JSON syntax errors.`;
+    }
+    PluginLogger.error(`[AM] ${errMessage}`, error.message);
+    if (tellUser) {
+      tellUser(errMessage);
+    }
+  }
+}
+
+/**
+ * Ensures the rules.json file exists, creating it with defaults if not.
+ */
+function ensureConfigFileExists(configDir) {
+  if (!fs.existsSync(configDir)) {
+    PluginLogger.info(`[AM] Creating configuration directory: ${configDir}`);
+    fs.mkdirSync(configDir, { recursive: true });
+  }
+  
+  if (!fs.existsSync(configFilePath)) {
+    PluginLogger.info(`[AM] Creating default rules file: ${configFilePath}`);
+    const defaultConfig = [
+      {
+        "server": "freenode",
+        "listen_channel": "#my-channel",
+        "trigger_text": "ping",
+        "response_message": "pong",
+        "response_channel": "",
+        "cooldown_seconds": 5
+      }
+    ];
+    fs.writeFileSync(configFilePath, JSON.stringify(defaultConfig, null, 2) + '\n');
+  }
+}
+
+/**
+ * Returns the current array of rules.
+ * @returns {Array<object>}
+ */
+function getRules() {
+  return rules;
+}
+
+/**
+ * Returns the path to the rules.json file.
+ * @returns {string}
+ */
+function getRulesPath() {
+  return configFilePath;
+}
+
+/**
+ * Returns the map of rule cooldowns.
+ * @returns {Map<object, number>}
+ */
+function getRuleCooldowns() {
+    return ruleCooldowns;
+}
+
+module.exports = {
+  init,
+  loadRules,
+  getRules,
+  getRulesPath,
+  getRuleCooldowns,
+};


### PR DESCRIPTION
The plugin code has been split into different modules to address an `index.js` file that was getting too big. The modules are split up to uphold a separation of concerns strategy. Refer to the `README.md` for a clearer and longer explanation of the new structure.

Some smaller changes were also implemented in this branch:
- The plugin will not try to answer private messages anymore. This needs a deeper reworking of the current plugin functionality and should be addressed, if necessary at all, at a later date.
- A couple of bug fixes to the already existing code. Refer to individual commits on this branch.

The project is now ready to address future enhancements that will probably add a significant amount of code addititions, like #13 and #11 