### PR TITLE
Fetch rules from url

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -3,6 +3,7 @@
 const { PluginLogger } = require('./logger');
 const pluginConfigManager = require('./plugin-config');
 const ruleManager = require('./rule-manager');
+const { validateRules } = require('./rule-validator');
 const { createPrivmsgHandler, safeJsonStringify } = require('./message-handler');
 
 // Key: network.uuid, Value: { handler: function, client: object }
@@ -26,6 +27,40 @@ function sendHelpMessage(tellUser) {
   tellUser("  debug status   - Shows if debug mode is currently ENABLED or DISABLED.");
   tellUser("  debug enable   - Enables verbose logging.");
   tellUser("  debug disable  - Disables verbose logging.");
+}
+
+/**
+* Displays the active rules for a given network to the user.
+* @param {object} network - The TheLounge network object.
+* @param {function(string)} tellUser - The function to send messages to the user.
+*/
+function displayRulesForNetwork(network, tellUser) {
+  const allRules = ruleManager.getRules();
+  const networkRules = allRules.filter(rule => rule.server === network.name);
+
+  if (networkRules.length === 0) {
+    tellUser(`No active rules found for this server (${network.name}).`);
+    return;
+  }
+
+  tellUser(`Active rules for this server (${network.name}):`);
+  networkRules.forEach((rule, index) => {
+    let responsePart = `-> "${rule.response_text}"`;
+    if (rule.response_channel && rule.response_channel !== rule.listen_channel) {
+      responsePart = `-> ${rule.response_channel}: "${rule.response_text}"`;
+    }
+
+    const options = [];
+    if (typeof rule.cooldown_seconds === 'number') {
+      options.push(`cooldown: ${rule.cooldown_seconds}s`);
+    }
+    if (typeof rule.delay_seconds === 'number' && rule.delay_seconds > 0) {
+      options.push(`delay: ${rule.delay_seconds}s`);
+    }
+    const optionsPart = options.length > 0 ? ` (${options.join(', ')})` : '';
+
+    tellUser(`${index + 1}. [${rule.listen_channel}] "${rule.trigger_text}" ${responsePart}${optionsPart}`);
+  });
 }
 
 const answeringMachineCommand = {
@@ -82,6 +117,15 @@ const answeringMachineCommand = {
         ruleManager.loadRules(tellUser);
         return;
       }
+
+      case 'rules': {
+        if (!activeListeners.has(network.uuid)) {
+          tellUser(`Listener is not active for this network (${network.name}). Use '/am start' to activate it.`);
+          return;
+        }
+        displayRulesForNetwork(network, tellUser);
+        break;
+      }
       
       case 'debug': {
         const [debugSubCommand] = args.slice(1);
@@ -119,6 +163,166 @@ const answeringMachineCommand = {
         return;
       }
       
+      case 'fetch': {
+        const [fetchSubCommand] = args.slice(1);
+        const config = pluginConfigManager.getPluginConfig();
+        switch ((fetchSubCommand || '').toLowerCase()) {
+          case 'enable': {
+            if (config.enableFetch) {
+              tellUser('Remote rule fetching is already ENABLED.');
+            } else {
+              config.enableFetch = true;
+              pluginConfigManager.savePluginConfig();
+              tellUser('Remote rule fetching has been ENABLED. The change has been saved.');
+            }
+            break;
+          }
+          case 'disable': {
+            if (!config.enableFetch) {
+              tellUser('Remote rule fetching is already DISABLED.');
+            } else {
+              config.enableFetch = false;
+              pluginConfigManager.savePluginConfig();
+              tellUser('Remote rule fetching has been DISABLED. The change has been saved.');
+            }
+            break;
+          }
+          case 'status': {
+            tellUser(`Remote rule fetching is currently ${config.enableFetch ? 'ENABLED' : 'DISABLED'}.`);
+            break;
+          }
+          default: {
+            (async () => {
+              const url = fetchSubCommand;
+              if (!url) {
+                tellUser('Usage: /am fetch <URL>');
+                return;
+              }
+              // 1. Check if the feature is enabled
+              if (!config.enableFetch) {
+                tellUser('Error: Remote rule fetching is disabled. Use \'/am fetch enable\' to activate it.');
+                return;
+              }
+
+              // 2. Check if the whitelist is configured
+              if (!config.fetchWhitelist || config.fetchWhitelist.length === 0) {
+                tellUser('Error: The domain whitelist is empty. Use \'/am whitelist add <domain>\' to add a trusted domain.');
+                return;
+              }
+
+              // 3. Validate URL and check against whitelist
+              let urlHostname;
+              try {
+                urlHostname = new URL(url).hostname;
+              } catch (e) {
+                tellUser(`Error: Invalid URL provided: "${url}"`);
+                return;
+              }
+
+              if (!config.fetchWhitelist.includes(urlHostname)) {
+                tellUser(`Error: The domain '${urlHostname}' is not in the whitelist.`);
+                return;
+              }
+
+              tellUser(`Fetching rules from whitelisted domain: ${urlHostname}...`);
+              
+              try {
+                const response = await fetch(url);
+                if (!response.ok) {
+                  throw new Error(`HTTP error! status: ${response.status} ${response.statusText}`);
+                }
+                const textBody = await response.text();
+
+                let newRules;
+                try {
+                  newRules = JSON.parse(textBody);
+                } catch (jsonError) {
+                  tellUser(`Error: Failed to parse JSON from ${url}. Please check the file for syntax errors.`);
+                  PluginLogger.error(`[AM] JSON parse error for ${url}:`, jsonError);
+                  return;
+                }
+
+                const validationResult = validateRules(newRules);
+                if (!validationResult.isValid) {
+                  tellUser(`Error: The fetched rules are invalid. ${validationResult.error}`);
+                  return;
+                }
+
+                tellUser('Validation successful. Merging rules...');
+                
+                const existingRules = ruleManager.getRules();
+                const { mergedRules, added, overwritten } = ruleManager.mergeRules(existingRules, newRules);
+                ruleManager.saveRules(mergedRules);
+
+                tellUser(`Fetch complete: ${added} rules added, ${overwritten} rules overwritten.`);
+                displayRulesForNetwork(network, tellUser);
+
+              } catch (fetchError) {
+                tellUser(`Error: Failed to fetch rules from ${url}.`);
+                PluginLogger.error(`[AM] Fetch error for ${url}:`, fetchError);
+              }
+            })();
+            break;
+          }
+        }
+        return;
+      }
+      
+      case 'whitelist': {
+        const [whitelistSubCommand, domain] = args.slice(1);
+        const config = pluginConfigManager.getPluginConfig();
+
+        // Ensure whitelist exists to prevent errors from a manually corrupted config
+        if (!Array.isArray(config.fetchWhitelist)) {
+          config.fetchWhitelist = [];
+        }
+
+        switch ((whitelistSubCommand || 'list').toLowerCase()) {
+          case 'add': {
+            if (!domain) {
+              tellUser('Usage: /am whitelist add <domain>');
+              break;
+            }
+            const lowerDomain = domain.toLowerCase();
+            if (config.fetchWhitelist.includes(lowerDomain)) {
+              tellUser(`Domain '${lowerDomain}' is already in the whitelist.`);
+            } else {
+              config.fetchWhitelist.push(lowerDomain);
+              pluginConfigManager.savePluginConfig();
+              tellUser(`Domain '${lowerDomain}' has been ADDED to the whitelist. The change has been saved.`);
+            }
+            break;
+          }
+          case 'remove': {
+            if (!domain) {
+              tellUser('Usage: /am whitelist remove <domain>');
+              break;
+            }
+            const lowerDomain = domain.toLowerCase();
+            const index = config.fetchWhitelist.indexOf(lowerDomain);
+            if (index === -1) {
+              tellUser(`Domain '${lowerDomain}' is not in the whitelist.`);
+            } else {
+              config.fetchWhitelist.splice(index, 1);
+              pluginConfigManager.savePluginConfig();
+              tellUser(`Domain '${lowerDomain}' has been REMOVED from the whitelist. The change has been saved.`);
+            }
+            break;
+          }
+          case 'list':
+          default: {
+            if (config.fetchWhitelist.length === 0) {
+              tellUser('The fetch domain whitelist is currently empty.');
+            } else {
+              tellUser('Current fetch domain whitelist:');
+              config.fetchWhitelist.forEach(d => tellUser(`- ${d}`));
+            }
+            break;
+          }
+        }
+        return;
+      }
+
       default: {
         sendHelpMessage(tellUser);
         return;
@@ -130,4 +334,5 @@ const answeringMachineCommand = {
 
 module.exports = {
   answeringMachineCommand,
+  activeListeners, // Export for testing purposes
 };

--- a/src/plugin-config.js
+++ b/src/plugin-config.js
@@ -4,8 +4,10 @@ const fs = require('fs');
 const path = require('path');
 const { PluginLogger } = require('./logger');
 
+const DEFAULT_CONFIG = { debug: false, enableFetch: false, fetchWhitelist: [] };
+
 // Default state
-let pluginConfig = { debug: false };
+let pluginConfig = { ...DEFAULT_CONFIG };
 let pluginConfigPath = '';
 
 /**
@@ -27,7 +29,7 @@ function loadPluginConfig() {
   try {
     const configFile = fs.readFileSync(pluginConfigPath, 'utf8');
     pluginConfig = JSON.parse(configFile);
-    PluginLogger.info(`[AM] Plugin config successfully loaded. Debug mode is ${pluginConfig.debug ? 'ENABLED' : 'DISABLED'}.`);
+    PluginLogger.info(`[AM] Plugin config successfully loaded.`);
   } catch (error) {
     let errMessage = `[AM] ERROR: Could not read plugin config from ${pluginConfigPath}. Using default values.`;
     if (error.code === 'ENOENT') {
@@ -36,6 +38,7 @@ function loadPluginConfig() {
       errMessage = `[AM] ERROR: Failed to parse ${pluginConfigPath}. Please check for JSON syntax errors. Using default values.`;
     }
     PluginLogger.error(errMessage, error.message);
+    pluginConfig = { ...DEFAULT_CONFIG };
   }
 }
 
@@ -58,7 +61,7 @@ function savePluginConfig() {
 function ensurePluginConfigExists() {
   if (!fs.existsSync(pluginConfigPath)) {
     PluginLogger.info(`[AM] Creating default plugin config file: ${pluginConfigPath}`);
-    const defaultConfig = { "debug": false };
+    const defaultConfig = { ...DEFAULT_CONFIG };
     fs.writeFileSync(pluginConfigPath, JSON.stringify(defaultConfig, null, 2) + '\n');
   }
 }

--- a/src/rule-validator.js
+++ b/src/rule-validator.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * Validates an array of rule objects against the required schema.
+ * This function mutates the rule objects in place by casting numeric string values to numbers.
+ * @param {any} rules - The parsed JSON data to validate.
+ * @returns {{isValid: boolean, error?: string}}
+ */
+function validateRules(rules) {
+  if (!Array.isArray(rules)) {
+    return { isValid: false, error: 'The provided rules data is not an array.' };
+  }
+
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i];
+
+    if (typeof rule !== 'object' || rule === null) {
+      return { isValid: false, error: `Rule #${i + 1} is not a valid object.` };
+    }
+
+    const requiredStrings = ['server', 'listen_channel', 'trigger_text', 'response_text'];
+    for (const prop of requiredStrings) {
+      if (typeof rule[prop] !== 'string' || rule[prop].trim() === '') {
+        return { isValid: false, error: `Rule #${i + 1} is missing or has an empty required string property: '${prop}'.` };
+      }
+    }
+
+    const numericFields = ['cooldown_seconds', 'delay_seconds'];
+    for (const field of numericFields) {
+      if (rule.hasOwnProperty(field)) {
+        const originalValue = rule[field];
+        
+        if (typeof originalValue === 'string' && originalValue.trim() !== '') {
+          const parsedValue = Number(originalValue);
+          if (isNaN(parsedValue)) {
+            return { isValid: false, error: `Rule #${i + 1} has a non-numeric string for '${field}': '${originalValue}'.` };
+          }
+          rule[field] = parsedValue; // Mutate the object with the correct type
+        } else if (typeof originalValue !== 'number') {
+          return { isValid: false, error: `Rule #${i + 1} has an invalid type for '${field}'. Expected a number or a numeric string.` };
+        }
+      }
+    }
+  }
+
+  return { isValid: true };
+}
+
+module.exports = {
+  validateRules,
+};

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -7,7 +7,7 @@ jest.mock('../src/message-handler', () => ({
   safeJsonStringify: jest.fn((obj) => JSON.stringify(obj)),
 }));
 
-const mockPluginConfig = { debug: false };
+const mockPluginConfig = { debug: false, enableFetch: false, fetchWhitelist: [] };
 jest.mock('../src/plugin-config', () => ({
   getPluginConfig: jest.fn(() => mockPluginConfig),
   savePluginConfig: jest.fn(),
@@ -15,9 +15,24 @@ jest.mock('../src/plugin-config', () => ({
 
 jest.mock('../src/rule-manager', () => ({
   loadRules: jest.fn(),
+  getRules: jest.fn(() => []),
+  mergeRules: jest.fn(),
+  saveRules: jest.fn(),
 }));
 
-const { answeringMachineCommand } = require('../src/commands');
+const { createPrivmsgHandler, safeJsonStringify } = require('../src/message-handler');
+
+// Mock the rule-validator module
+jest.mock('../src/rule-validator', () => ({
+  validateRules: jest.fn(),
+}));
+
+const { validateRules } = require('../src/rule-validator');
+
+// Mock the global fetch API
+global.fetch = jest.fn();
+
+const { answeringMachineCommand, activeListeners } = require('../src/commands');
 
 describe('Answering Machine Command (/am)', () => {
   let client;
@@ -25,16 +40,16 @@ describe('Answering Machine Command (/am)', () => {
   let network;
 
   beforeEach(() => {
-    // Clear mock usage history and reset module state before each test
+    // Clear mock usage history before each test
     jest.clearAllMocks();
-    // Reset the activeListeners map by re-requiring the module.
-    // This is safe now because the mocks are defined at the top level.
-    jest.resetModules();
-    const commandsModule = require('../src/commands');
-    Object.assign(answeringMachineCommand, commandsModule.answeringMachineCommand);
+    // Manually reset the state of the command module instead of using jest.resetModules()
+    activeListeners.clear();
 
     // Reset our manual mock state
     mockPluginConfig.debug = false;
+    mockPluginConfig.enableFetch = false;
+    mockPluginConfig.fetchWhitelist = [];
+
 
     // Mock the TheLounge client environment
     client = {
@@ -160,6 +175,265 @@ describe('Answering Machine Command (/am)', () => {
       runCommand(['debug', 'disable']);
       expect(require('../src/plugin-config').savePluginConfig).not.toHaveBeenCalled();
       expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Debug mode is already DISABLED'), 1);
+    });
+  });
+
+  describe('fetch (admin)', () => {
+    it('status: should report when fetch is DISABLED', () => {
+        runCommand(['fetch', 'status']);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Remote rule fetching is currently DISABLED'), 1);
+    });
+
+    it('status: should report when fetch is ENABLED', () => {
+        mockPluginConfig.enableFetch = true;
+        runCommand(['fetch', 'status']);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Remote rule fetching is currently ENABLED'), 1);
+    });
+
+    it('enable: should enable fetch mode', () => {
+        runCommand(['fetch', 'enable']);
+        expect(mockPluginConfig.enableFetch).toBe(true);
+        expect(require('../src/plugin-config').savePluginConfig).toHaveBeenCalled();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Remote rule fetching has been ENABLED'), 1);
+    });
+
+    it('enable: should do nothing if already enabled', () => {
+        mockPluginConfig.enableFetch = true;
+        runCommand(['fetch', 'enable']);
+        expect(require('../src/plugin-config').savePluginConfig).not.toHaveBeenCalled();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Remote rule fetching is already ENABLED'), 1);
+    });
+
+    it('disable: should disable fetch mode', () => {
+        mockPluginConfig.enableFetch = true;
+        runCommand(['fetch', 'disable']);
+        expect(mockPluginConfig.enableFetch).toBe(false);
+        expect(require('../src/plugin-config').savePluginConfig).toHaveBeenCalled();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Remote rule fetching has been DISABLED'), 1);
+    });
+
+    it('disable: should do nothing if already disabled', () => {
+        mockPluginConfig.enableFetch = false;
+        runCommand(['fetch', 'disable']);
+        expect(require('../src/plugin-config').savePluginConfig).not.toHaveBeenCalled();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Remote rule fetching is already DISABLED'), 1);
+    });
+  });
+
+  describe('whitelist', () => {
+    it('list: should report an empty whitelist', () => {
+        runCommand(['whitelist', 'list']);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('whitelist is currently empty'), 1);
+    });
+
+    it('list: should list all domains in the whitelist', () => {
+        mockPluginConfig.fetchWhitelist = ['example.com', 'test.org'];
+        runCommand(['whitelist', 'list']);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Current fetch domain whitelist:'), 1);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('- example.com'), 1);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('- test.org'), 1);
+    });
+
+    it('add: should add a new domain to the whitelist', () => {
+        runCommand(['whitelist', 'add', 'example.com']);
+        expect(mockPluginConfig.fetchWhitelist).toContain('example.com');
+        expect(require('../src/plugin-config').savePluginConfig).toHaveBeenCalled();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('has been ADDED'), 1);
+    });
+
+    it('add: should not add a duplicate domain', () => {
+        mockPluginConfig.fetchWhitelist = ['example.com'];
+        runCommand(['whitelist', 'add', 'example.com']);
+        expect(mockPluginConfig.fetchWhitelist.length).toBe(1);
+        expect(require('../src/plugin-config').savePluginConfig).not.toHaveBeenCalled();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('is already in the whitelist'), 1);
+    });
+
+    it('add: should show usage if no domain is provided', () => {
+        runCommand(['whitelist', 'add']);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Usage: /am whitelist add <domain>'), 1);
+    });
+
+    it('remove: should remove an existing domain', () => {
+        mockPluginConfig.fetchWhitelist = ['example.com', 'test.org'];
+        runCommand(['whitelist', 'remove', 'example.com']);
+        expect(mockPluginConfig.fetchWhitelist).not.toContain('example.com');
+        expect(mockPluginConfig.fetchWhitelist).toContain('test.org');
+        expect(require('../src/plugin-config').savePluginConfig).toHaveBeenCalled();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('has been REMOVED'), 1);
+    });
+
+    it('remove: should do nothing if domain is not in the list', () => {
+        mockPluginConfig.fetchWhitelist = ['test.org'];
+        runCommand(['whitelist', 'remove', 'example.com']);
+        expect(mockPluginConfig.fetchWhitelist.length).toBe(1);
+        expect(require('../src/plugin-config').savePluginConfig).not.toHaveBeenCalled();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('is not in the whitelist'), 1);
+    });
+
+    it('remove: should show usage if no domain is provided', () => {
+        runCommand(['whitelist', 'remove']);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Usage: /am whitelist remove <domain>'), 1);
+    });
+  });
+
+  describe('/am rules', () => {
+    const ruleManager = require('../src/rule-manager');
+
+    it('should report an error if the listener is not active', () => {
+        runCommand(['rules']);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Listener is not active'), 1);
+    });
+
+    it('should report when no rules are found for the current server', () => {
+        runCommand(['start']); // Activate listener
+        ruleManager.getRules.mockReturnValue([]);
+        runCommand(['rules']);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('No active rules found for this server (TestNet)'), 1);
+    });
+
+    it('should not show rules for other servers', () => {
+        runCommand(['start']);
+        const otherServerRule = { server: 'OtherNet', listen_channel: '#a', trigger_text: 'a', response_text: 'b' };
+        ruleManager.getRules.mockReturnValue([otherServerRule]);
+        runCommand(['rules']);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('No active rules found for this server (TestNet)'), 1);
+    });
+
+    it('should display a single, simple rule correctly', () => {
+        runCommand(['start']);
+        const rule = { server: 'TestNet', listen_channel: '#general', trigger_text: 'help', response_text: 'read the docs' };
+        ruleManager.getRules.mockReturnValue([rule]);
+        runCommand(['rules']);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('1. [#general] "help" -> "read the docs"'), 1);
+    });
+
+    it('should display multiple complex rules with correct formatting', () => {
+        runCommand(['start']);
+        const rules = [
+            { server: 'TestNet', listen_channel: '#a', trigger_text: 't1', response_text: 'r1', response_channel: 'user', cooldown_seconds: 10 },
+            { server: 'TestNet', listen_channel: '#b', trigger_text: 't2', response_text: 'r2', delay_seconds: 5 },
+            { server: 'TestNet', listen_channel: '#c', trigger_text: 't3', response_text: 'r3', cooldown_seconds: 30, delay_seconds: 3 }
+        ];
+        ruleManager.getRules.mockReturnValue(rules);
+        runCommand(['rules']);
+
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Active rules for this server (TestNet):'), 1);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('1. [#a] "t1" -> user: "r1" (cooldown: 10s)'), 1);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('2. [#b] "t2" -> "r2" (delay: 5s)'), 1);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('3. [#c] "t3" -> "r3" (cooldown: 30s, delay: 3s)'), 1);
+    });
+  });
+
+  describe('/am fetch <URL>', () => {
+    const { validateRules } = require('../src/rule-validator');
+    const ruleManager = require('../src/rule-manager');
+    const validUrl = 'https://example.com/rules.json';
+
+    // Helper to wait for the async IIFE in the command to finish
+    const waitForAsync = () => new Promise(resolve => setImmediate(resolve));
+
+    beforeEach(() => {
+        // Reset mocks before each fetch test
+        global.fetch.mockClear();
+        validateRules.mockClear();
+        ruleManager.getRules.mockClear();
+        ruleManager.mergeRules.mockClear();
+        ruleManager.saveRules.mockClear();
+    });
+
+    it('should fail if fetch is disabled', async () => {
+        mockPluginConfig.enableFetch = false;
+        runCommand(['fetch', validUrl]);
+        await waitForAsync();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Error: Remote rule fetching is disabled'), 1);
+    });
+
+    it('should fail if whitelist is empty', async () => {
+        mockPluginConfig.enableFetch = true;
+        mockPluginConfig.fetchWhitelist = [];
+        runCommand(['fetch', validUrl]);
+        await waitForAsync();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Error: The domain whitelist is empty'), 1);
+    });
+
+    it('should fail if domain is not in whitelist', async () => {
+        mockPluginConfig.enableFetch = true;
+        mockPluginConfig.fetchWhitelist = ['another.com'];
+        runCommand(['fetch', validUrl]);
+        await waitForAsync();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining("Error: The domain 'example.com' is not in the whitelist"), 1);
+    });
+
+    it('should fail for an invalid URL', async () => {
+        mockPluginConfig.enableFetch = true;
+        mockPluginConfig.fetchWhitelist = ['example.com'];
+        runCommand(['fetch', 'not-a-valid-url']);
+        await waitForAsync();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Error: Invalid URL provided'), 1);
+    });
+
+    it('should handle network errors during fetch', async () => {
+        mockPluginConfig.enableFetch = true;
+        mockPluginConfig.fetchWhitelist = ['example.com'];
+        global.fetch.mockRejectedValue(new Error('Network Failure'));
+        runCommand(['fetch', validUrl]);
+        await waitForAsync();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Error: Failed to fetch rules'), 1);
+    });
+
+    it('should handle non-OK HTTP responses', async () => {
+        mockPluginConfig.enableFetch = true;
+        mockPluginConfig.fetchWhitelist = ['example.com'];
+        global.fetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+        runCommand(['fetch', validUrl]);
+        await waitForAsync();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Error: Failed to fetch rules'), 1);
+    });
+
+    it('should handle invalid JSON responses', async () => {
+        mockPluginConfig.enableFetch = true;
+        mockPluginConfig.fetchWhitelist = ['example.com'];
+        global.fetch.mockResolvedValue({ ok: true, text: () => Promise.resolve('this is not json') });
+        runCommand(['fetch', validUrl]);
+        await waitForAsync();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Error: Failed to parse JSON'), 1);
+    });
+
+    it('should fail if rule validation fails', async () => {
+        mockPluginConfig.enableFetch = true;
+        mockPluginConfig.fetchWhitelist = ['example.com'];
+        global.fetch.mockResolvedValue({ ok: true, text: () => Promise.resolve('[]') });
+        validateRules.mockReturnValue({ isValid: false, error: 'Test validation error' });
+        runCommand(['fetch', validUrl]);
+        await waitForAsync();
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Error: The fetched rules are invalid. Test validation error'), 1);
+    });
+
+    it('should complete the full success path', async () => {
+        // Arrange
+        mockPluginConfig.enableFetch = true;
+        mockPluginConfig.fetchWhitelist = ['example.com'];
+        const newRules = [{ server: 'TestNet', listen_channel: '#new', trigger_text: 'new', response_text: 'rule' }];
+        global.fetch.mockResolvedValue({ ok: true, text: () => Promise.resolve(JSON.stringify(newRules)) });
+        validateRules.mockReturnValue({ isValid: true });
+        ruleManager.mergeRules.mockReturnValue({ mergedRules: newRules, added: 1, overwritten: 0 });
+
+        // Simulate the two states of getRules: before and after the fetch/save.
+        ruleManager.getRules
+            .mockReturnValueOnce([]) // First call for existingRules
+            .mockReturnValue(newRules); // Subsequent calls for displayRulesForNetwork
+
+        // Act
+        runCommand(['fetch', validUrl]);
+        await waitForAsync();
+
+        // Assert
+        expect(ruleManager.mergeRules).toHaveBeenCalledWith([], newRules);
+        expect(ruleManager.saveRules).toHaveBeenCalledWith(newRules);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Fetch complete: 1 rules added, 0 rules overwritten.'), 1);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Active rules for this server (TestNet):'), 1);
+        expect(client.sendMessage).toHaveBeenCalledWith(expect.stringContaining('1. [#new] "new" -> "rule"'), 1);
     });
   });
 });

--- a/test/plugin-config.test.js
+++ b/test/plugin-config.test.js
@@ -33,24 +33,25 @@ describe('Plugin Config Manager', () => {
   describe('init', () => {
     it('should create a default config.json if one does not exist', () => {
       fs.existsSync.mockReturnValue(false);
-      fs.readFileSync.mockReturnValue(JSON.stringify({ debug: false }));
+      fs.readFileSync.mockReturnValue(JSON.stringify({ debug: false, enableFetch: false, fetchWhitelist: [] }));
 
       pluginConfigManager.init(configDir);
 
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         configFilePath,
-        JSON.stringify({ debug: false }, null, 2) + '\n'
+        JSON.stringify({ debug: false, enableFetch: false, fetchWhitelist: [] }, null, 2) + '\n'
       );
     });
 
     it('should load the config from an existing file', () => {
       fs.existsSync.mockReturnValue(true);
-      fs.readFileSync.mockReturnValue(JSON.stringify({ debug: true, other: 'value' }));
+      const mockConfig = { debug: true, enableFetch: true, fetchWhitelist: ['example.com'], other: 'value' };
+      fs.readFileSync.mockReturnValue(JSON.stringify(mockConfig));
 
       pluginConfigManager.init(configDir);
 
       expect(fs.writeFileSync).not.toHaveBeenCalled();
-      expect(pluginConfigManager.getPluginConfig()).toEqual({ debug: true, other: 'value' });
+      expect(pluginConfigManager.getPluginConfig()).toEqual(mockConfig);
     });
   });
 
@@ -62,7 +63,7 @@ describe('Plugin Config Manager', () => {
       pluginConfigManager.init(configDir);
 
       expect(pluginConfigManager.getPluginConfig()).toEqual(mockConfig);
-      expect(PluginLogger.info).toHaveBeenCalledWith(expect.stringContaining('Plugin config successfully loaded. Debug mode is ENABLED'));
+      expect(PluginLogger.info).toHaveBeenCalledWith(expect.stringContaining('Plugin config successfully loaded.'));
     });
 
     it('should use default config on JSON syntax error', () => {
@@ -75,7 +76,7 @@ describe('Plugin Config Manager', () => {
         expect.stringContaining('Failed to parse'),
         expect.any(String)
       );
-      expect(pluginConfigManager.getPluginConfig()).toEqual({ debug: false });
+      expect(pluginConfigManager.getPluginConfig()).toEqual({ debug: false, enableFetch: false, fetchWhitelist: [] });
     });
 
     it('should use default config on file not found error', () => {
@@ -90,7 +91,7 @@ describe('Plugin Config Manager', () => {
         expect.stringContaining('Plugin config file not found'),
         expect.any(String)
       );
-      expect(pluginConfigManager.getPluginConfig()).toEqual({ debug: false });
+      expect(pluginConfigManager.getPluginConfig()).toEqual({ debug: false, enableFetch: false, fetchWhitelist: [] });
     });
   });
 

--- a/test/rule-validator.test.js
+++ b/test/rule-validator.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const { validateRules } = require('../src/rule-validator');
+
+describe('Rule Validator', () => {
+  const createValidRule = (overrides = {}) => ({
+    server: 'TestNet',
+    listen_channel: '#test',
+    trigger_text: 'ping',
+    response_text: 'pong',
+    ...overrides,
+  });
+
+  describe('Valid Data', () => {
+    it('should return valid for a correct single rule', () => {
+      const rules = [createValidRule()];
+      expect(validateRules(rules)).toEqual({ isValid: true });
+    });
+
+    it('should return valid for multiple correct rules', () => {
+      const rules = [createValidRule(), createValidRule({ server: 'OtherNet' })];
+      expect(validateRules(rules)).toEqual({ isValid: true });
+    });
+
+    it('should return valid for an empty array of rules', () => {
+      const rules = [];
+      expect(validateRules(rules)).toEqual({ isValid: true });
+    });
+
+    it('should return valid and correctly cast numeric strings', () => {
+      const rules = [createValidRule({ cooldown_seconds: '10', delay_seconds: '5.5' })];
+      const result = validateRules(rules);
+      expect(result).toEqual({ isValid: true });
+      expect(rules[0].cooldown_seconds).toBe(10);
+      expect(rules[0].delay_seconds).toBe(5.5);
+    });
+
+    it('should handle optional fields being numbers already', () => {
+        const rules = [createValidRule({ cooldown_seconds: 15, delay_seconds: 0 })];
+        const result = validateRules(rules);
+        expect(result).toEqual({ isValid: true });
+        expect(rules[0].cooldown_seconds).toBe(15);
+    });
+  });
+
+  describe('Invalid Data Structure', () => {
+    it('should return invalid if input is not an array', () => {
+      expect(validateRules({})).toEqual({ isValid: false, error: 'The provided rules data is not an array.' });
+      expect(validateRules(null)).toEqual({ isValid: false, error: 'The provided rules data is not an array.' });
+      expect(validateRules('string')).toEqual({ isValid: false, error: 'The provided rules data is not an array.' });
+    });
+
+    it('should return invalid if an item in the array is not an object', () => {
+      expect(validateRules([null])).toEqual({ isValid: false, error: 'Rule #1 is not a valid object.' });
+      expect(validateRules([createValidRule(), 'string'])).toEqual({ isValid: false, error: 'Rule #2 is not a valid object.' });
+    });
+  });
+
+  describe('Invalid Rule Properties', () => {
+    const requiredProps = ['server', 'listen_channel', 'trigger_text', 'response_text'];
+    
+    requiredProps.forEach(prop => {
+      it(`should return invalid if required property '${prop}' is missing`, () => {
+        const rule = createValidRule();
+        delete rule[prop];
+        expect(validateRules([rule])).toEqual({ isValid: false, error: `Rule #1 is missing or has an empty required string property: '${prop}'.` });
+      });
+
+      it(`should return invalid if required property '${prop}' is an empty string`, () => {
+        const rule = createValidRule({ [prop]: '   ' });
+        expect(validateRules([rule])).toEqual({ isValid: false, error: `Rule #1 is missing or has an empty required string property: '${prop}'.` });
+      });
+
+      it(`should return invalid if required property '${prop}' is not a string`, () => {
+        const rule = createValidRule({ [prop]: 123 });
+        expect(validateRules([rule])).toEqual({ isValid: false, error: `Rule #1 is missing or has an empty required string property: '${prop}'.` });
+      });
+    });
+
+    it('should return invalid for a non-numeric string in cooldown_seconds', () => {
+      const rules = [createValidRule({ cooldown_seconds: 'abc' })];
+      expect(validateRules(rules)).toEqual({ isValid: false, error: "Rule #1 has a non-numeric string for 'cooldown_seconds': 'abc'." });
+    });
+
+    it('should return invalid for a non-numeric or non-string type in delay_seconds', () => {
+      const rules = [createValidRule({ delay_seconds: {} })];
+      expect(validateRules(rules)).toEqual({ isValid: false, error: "Rule #1 has an invalid type for 'delay_seconds'. Expected a number or a numeric string." });
+    });
+  });
+});


### PR DESCRIPTION
A few key changes were added:
- Rules can now be fetched through a remote URL. If the flow succeeds, it will merge the fetched rules with the existing ones and persist them to the `rules.json` file. **However**, since this poses a security risk because of the potential por SSRF attacks, this feature has to be explicitly enabled (which can be done using `/am fetch enable`) and will only work on whitelisted domains (which can be set using `/am whitelist add {{domain}}`. 
- The user can now see all active rules for a server using the new `/am rules` command. It will also be called after a successful merge of rules when remote URL fetching is finished. 

Please refer to the README for more detailed documentation on this features and report any issues you find.

This solves #20 and #21 